### PR TITLE
Change default encoding to binary, instead of hex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,5 @@
+# 0.2.0
+* Breaking: added option to encode RLP to either hex strings (`"8055FF"`) or binaries (`<<0x80, 0x55, 0xFF>`). The default is now `:binary`.
+* Added typespecs and additional test coverage through doctests.
 # 0.1.1
 * Adds protocols for encoding/decoding maps

--- a/README.md
+++ b/README.md
@@ -27,17 +27,23 @@ And run:
 Use ExRLP.encode/1 method to encode an item to RLP representation. An item can be nonnegative integer, binary or list. List can contain integers, binaries or lists.
 
 ```elixir
-
   ## Examples
   
-  iex(1)> "dog" |> ExRLP.encode
-  "83646f67"
-  
-  iex(2)> 1000 |> ExRLP.encode
-  "8203e8"
-  
-  iex(3)> [ [ [], [] ], [] ] |> ExRLP.encode
-  "c4c2c0c0c0"
+      iex(1)> "dog" |> ExRLP.encode(encoding: :hex)
+      "83646f67"
+
+      iex(2)> "dog" |> ExRLP.encode(encoding: :binary)
+      <<0x83, 0x64, 0x6f, 0x67>>
+
+      iex(3)> 1000 |> ExRLP.encode(encoding: :hex)
+      "8203e8"
+
+      # Default encoding is binary
+      iex(3)> 1000 |> ExRLP.encode
+      <<0x82, 0x03, 0xe8>>
+
+      iex(4)> [ [ [], [] ], [] ] |> ExRLP.encode(encoding: :hex)
+      "c4c2c0c0c0"
 ```
 
 Use ExRLP.decode/1 method to decode a rlp encoded data. All items except lists are decoded as binaries so additional deserialization is needed if initially an item of another type was encoded.
@@ -47,14 +53,14 @@ Use ExRLP.decode/1 method to decode a rlp encoded data. All items except lists a
 
   ## Examples
   
-  iex(1)> "83646f67" |> ExRLP.decode
-  "dog"
-  
-  iex(2)> "8203e8" |> ExRLP.decode |> :binary.decode_unsigned
-  1000
-  
-  iex(3)> "c4c2c0c0c0" |> ExRLP.decode
-  [[[], []], []]
+      iex(1)> "83646f67" |> ExRLP.decode(:binary, encoding: :hex)
+      "dog"
+
+      iex(2)> "8203e8" |> ExRLP.decode(:binary, encoding: :hex) |> :binary.decode_unsigned
+      1000
+
+      iex(3)> "c4c2c0c0c0" |> ExRLP.decode(:binary, encoding: :hex)
+      [[[], []], []]
 ```
 
 More examples can be found in test files.
@@ -70,10 +76,6 @@ Custom protocols for Map have already been implemented in ExRLP:
 defimpl ExRLP.Encoder, for: Map do
   alias ExRLP.Encode
 
-  def encode(map, _) when map_size(map) < 1 do
-    "827b7d"
-  end
-
   def encode(map, _) do
     map
     |> Map.keys
@@ -88,10 +90,6 @@ end
 
 defimpl ExRLP.Decoder, for: BitString do
   alias ExRLP.Decode
-
-  def decode("827b7d", :map, _) do
-    %{}
-  end
 
   def decode(value, :map, options) do
     keys =
@@ -114,10 +112,10 @@ end
 ```
 So now it's possible to encode/decode maps:
 ```elixir
-iex(1)> %{name: "Vitalik", surname: "Buterin"} |> ExRLP.encode
+iex(1)> %{name: "Vitalik", surname: "Buterin"} |> ExRLP.encode(encoding: :hex)
 "d087566974616c696b874275746572696e"
 
-iex(2)> "d087566974616c696b874275746572696e" |> ExRLP.decode(:map, keys: [:surname, :name])
+iex(2)> "d087566974616c696b874275746572696e" |> ExRLP.decode(:map, keys: [:surname, :name], encoding: :hex)
 %{name: "Vitalik", surname: "Buterin"}
 ```
 

--- a/lib/ex_rlp.ex
+++ b/lib/ex_rlp.ex
@@ -3,11 +3,104 @@ defmodule ExRLP do
 
   @moduledoc File.read!("#{__DIR__}/../README.md")
 
-  def encode(item, options \\ nil) do
+  @type t :: nil | [t] | binary()
+
+  @doc """
+  Given an RLP structure, returns the encoding as a string.
+
+  ## Examples
+
+    iex> ExRLP.encode("dog")
+    <<0x83, ?d, ?o, ?g>>
+
+    iex> ExRLP.encode("dog", encoding: :hex)
+    "83646f67"
+
+    iex> ExRLP.encode(Enum.join(for _ <- 1..60, do: "A"))
+    <<184, 60, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65>>
+
+    iex> ExRLP.encode(["cat", "dog"])
+    <<0xc8, 0x83, ?c, ?a, ?t, 0x83, ?d, ?o, ?g>>
+
+    iex> ExRLP.encode("")
+    <<0x80>>
+
+    iex> ExRLP.encode([])
+    <<0xc0>>
+
+    iex> ExRLP.encode("\x0f")
+    <<0x0f>>
+
+    iex> ExRLP.encode(15)
+    <<0x0f>>
+
+    iex> ExRLP.encode(15_000_000_000_000_000_000_000_000_000_000_000)
+    <<143, 2, 227, 142, 158, 4, 75, 160, 83, 84, 85, 150, 0, 0, 0, 0>>
+
+    iex> ExRLP.encode(1024)
+    <<0x82, 0x04, 0x00>>
+
+    iex> ExRLP.encode("\x04\x00")
+    <<0x82, 0x04, 0x00>>
+
+    iex> ExRLP.encode([[],[[]],[[],[[]]]])
+    <<0xc7, 0xc0, 0xc1, 0xc0, 0xc3, 0xc0, 0xc1, 0xc0>>
+
+    iex> ExRLP.encode(for _ <- 1..60, do: [])
+    <<248, 60, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192>>
+  """
+  @spec encode(t, keyword()) :: binary()
+  def encode(item, options \\ []) do
     item |> Encoder.encode(options)
   end
 
-  def decode(item, type \\ :binary, options \\ nil) do
+  @doc """
+  Given an RLP-encoded string, returns a decoded RPL structure (which is an array of RLP structures or binaries).
+
+  ## Examples
+
+    iex> ExRLP.decode(<<>>)
+    nil
+
+    iex> ExRLP.decode(<<0x83, ?d, ?o, ?g>>)
+    "dog"
+
+    iex> ExRLP.decode("83646f67", :binary, encoding: :hex)
+    "dog"
+
+    iex> ExRLP.decode(<<184, 60, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65>>)
+    Enum.join(for _ <- 1..60, do: "A")
+
+    iex> ExRLP.decode(<<0xc8, 0x83, ?c, ?a, ?t, 0x83, ?d, ?o, ?g>>)
+    ["cat", "dog"]
+
+    iex> ExRLP.decode(<<198, 51, 132, 99, 111, 111, 108>>)
+    ["3", "cool"]
+
+    iex> ExRLP.decode(<<0x80>>)
+    ""
+
+    iex> ExRLP.decode(<<0xc0>>)
+    []
+
+    iex> ExRLP.decode(<<0x0f>>)
+    <<0x0f>>
+
+    iex> ExRLP.decode(<<0x82, 0x04, 0x00>>)
+    "\x04\x00"
+
+    iex> ExRLP.decode(<<0xc7, 0xc0, 0xc1, 0xc0, 0xc3, 0xc0, 0xc1, 0xc0>>)
+    [[],[[]],[[],[[]]]]
+
+    iex> ExRLP.decode(<<248, 60, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192>>)
+    for _ <- 1..60, do: []
+
+    iex> ExRLP.decode(<<143, 2, 227, 142, 158, 4, 75, 160, 83, 84, 85, 150, 0, 0, 0, 0>>) |> :binary.decode_unsigned
+    15_000_000_000_000_000_000_000_000_000_000_000
+  """
+  @spec decode(binary(), atom(), keyword()) :: t
+  def decode(item, type \\ :binary, options \\ []) do
     item |> Decoder.decode(type, options)
   end
+
 end

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule ExRLP.Mixfile do
      elixir: "~> 1.4",
      description: "Ethereum's Recursive Length Prefix (RLP) encoding",
      package: [
-       maintainers: ["Ayrat Badykov"],
+       maintainers: ["Ayrat Badykov", "Geoffrey Hayes"],
        licenses: ["MIT"],
        links: %{"GitHub" => "https://github.com/exthereum/ex_rlp"}
      ],
@@ -23,7 +23,8 @@ defmodule ExRLP.Mixfile do
   defp deps do
     [
       {:credo, "~> 0.8", only: [:dev, :test], runtime: false},
-      {:ex_doc, "~> 0.14", only: :dev, runtime: false}
+      {:ex_doc, "~> 0.14", only: :dev, runtime: false},
+      {:dialyxir, "~> 0.5", only: [:dev], runtime: false},
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule ExRLP.Mixfile do
 
   def project do
     [app: :ex_rlp,
-     version: "0.1.1",
+     version: "0.2.0",
      elixir: "~> 1.4",
      description: "Ethereum's Recursive Length Prefix (RLP) encoding",
      package: [

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
 %{"bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
   "credo": {:hex, :credo, "0.8.1", "137efcc99b4bc507c958ba9b5dff70149e971250813cbe7d4537ec7e36997402", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}], "hexpm"},
+  "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.16.1", "b4b8a23602b4ce0e9a5a960a81260d1f7b29635b9652c67e95b0c2f7ccee5e81", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"}}

--- a/test/ex_rlp/decoder_test.exs
+++ b/test/ex_rlp/decoder_test.exs
@@ -6,7 +6,7 @@ defmodule ExRLP.DecoderTest do
     rlp_binary = "80"
     expected_result = ""
 
-    result = rlp_binary |> Decoder.decode
+    result = rlp_binary |> Decoder.decode(:binary, encoding: :hex)
 
     assert result == expected_result
   end
@@ -15,7 +15,7 @@ defmodule ExRLP.DecoderTest do
     rlp_binary = "00"
     expected_result = "\u0000"
 
-    result = rlp_binary |> Decoder.decode
+    result = rlp_binary |> Decoder.decode(:binary, encoding: :hex)
 
     assert result == expected_result
   end
@@ -24,7 +24,7 @@ defmodule ExRLP.DecoderTest do
     rlp_binary = "01"
     expected_result = "\u0001"
 
-    result = rlp_binary |> Decoder.decode
+    result = rlp_binary |> Decoder.decode(:binary, encoding: :hex)
 
     assert result == expected_result
   end
@@ -33,7 +33,7 @@ defmodule ExRLP.DecoderTest do
     rlp_binary = "7f"
     expected_result = "\u007F"
 
-    result = rlp_binary |> Decoder.decode
+    result = rlp_binary |> Decoder.decode(:binary, encoding: :hex)
 
     assert result == expected_result
   end
@@ -42,7 +42,7 @@ defmodule ExRLP.DecoderTest do
     rlp_binary = "83646f67"
     expected_result = "dog"
 
-    result = rlp_binary |> Decoder.decode
+    result = rlp_binary |> Decoder.decode(:binary, encoding: :hex)
 
     assert result == expected_result
   end
@@ -52,7 +52,7 @@ defmodule ExRLP.DecoderTest do
       "420616d65742c20636f6e7365637465747572206164697069736963696e6720656c69"
     expected_result = "Lorem ipsum dolor sit amet, consectetur adipisicing eli"
 
-    result = rlp_binary |> Decoder.decode
+    result = rlp_binary |> Decoder.decode(:binary, encoding: :hex)
 
     assert result == expected_result
   end
@@ -62,7 +62,7 @@ defmodule ExRLP.DecoderTest do
       "420616d65742c20636f6e7365637465747572206164697069736963696e6720656c6974"
     expected_result = "Lorem ipsum dolor sit amet, consectetur adipisicing elit"
 
-    result = rlp_binary |> Decoder.decode
+    result = rlp_binary |> Decoder.decode(:binary, encoding: :hex)
 
     assert result == expected_result
   end
@@ -108,7 +108,7 @@ defmodule ExRLP.DecoderTest do
       "lorem libero aliquet arcu, non interdum tellus lectus sit amet eros. Cras rhoncus, " <>
       "metus ac ornare cursus, dolor justo ultrices metus, at ullamcorper volutpat"
 
-    result = rlp_binary |> Decoder.decode
+    result = rlp_binary |> Decoder.decode(:binary, encoding: :hex)
 
     assert result == expected_result
   end
@@ -117,7 +117,7 @@ defmodule ExRLP.DecoderTest do
     rlp_binary = "cc83646f6783676f6483636174"
     expected_result = [ "dog", "god", "cat" ]
 
-    result = rlp_binary |> Decoder.decode
+    result = rlp_binary |> Decoder.decode(:binary, encoding: :hex)
 
     assert result == expected_result
   end
@@ -128,7 +128,7 @@ defmodule ExRLP.DecoderTest do
     expected_result = [ "asdf", "qwer", "zxcv", "asdf","qwer",
                         "zxcv", "asdf", "qwer", "zxcv", "asdf", "qwer"]
 
-    result = rlp_binary |> Decoder.decode
+    result = rlp_binary |> Decoder.decode(:binary, encoding: :hex)
 
     assert result == expected_result
   end
@@ -188,7 +188,7 @@ defmodule ExRLP.DecoderTest do
       ["asdf","qwer","zxcv"]
     ]
 
-    result = rlp_binary |> Decoder.decode
+    result = rlp_binary |> Decoder.decode(:binary, encoding: :hex)
 
     assert result == expected_result
   end
@@ -197,7 +197,7 @@ defmodule ExRLP.DecoderTest do
     rlp_binary = "c4c2c0c0c0"
     expected_result = [ [ [], [] ], [] ]
 
-    result = rlp_binary |> Decoder.decode
+    result = rlp_binary |> Decoder.decode(:binary, encoding: :hex)
 
     assert result == expected_result
   end
@@ -206,7 +206,7 @@ defmodule ExRLP.DecoderTest do
     rlp_binary = "c7c0c1c0c3c0c1c0"
     expected_result = [ [], [[]], [ [], [[]] ] ]
 
-    result = rlp_binary |> Decoder.decode
+    result = rlp_binary |> Decoder.decode(:binary, encoding: :hex)
 
     assert result == expected_result
   end
@@ -221,7 +221,7 @@ defmodule ExRLP.DecoderTest do
       ["key4", "val4"]
     ]
 
-    result = rlp_binary |> Decoder.decode
+    result = rlp_binary |> Decoder.decode(:binary, encoding: :hex)
 
     assert result == expected_result
   end
@@ -230,7 +230,7 @@ defmodule ExRLP.DecoderTest do
     rlp_binary = "da8b526f636b276e27526f6c6c85417972617487426164796b6f76"
     expected_result = %{name: "Ayrat", surname: "Badykov", music: "Rock'n'Roll"}
 
-    result = rlp_binary |> Decoder.decode(:map, keys: [:name, :surname, :music])
+    result = rlp_binary |> Decoder.decode(:map, keys: [:name, :surname, :music], encoding: :hex)
 
     assert result == expected_result
   end

--- a/test/ex_rlp/encoder_test.exs
+++ b/test/ex_rlp/encoder_test.exs
@@ -6,7 +6,7 @@ defmodule ExRLP.EncoderTest do
     string = ""
     expected_result = "80"
 
-    result = string |> Encoder.encode
+    result = string |> Encoder.encode(encoding: :hex)
 
     assert result == expected_result
   end
@@ -15,7 +15,7 @@ defmodule ExRLP.EncoderTest do
     string =  "\u0000"
     expected_result = "00"
 
-    result = string |> Encoder.encode
+    result = string |> Encoder.encode(encoding: :hex)
 
     assert result == expected_result
   end
@@ -24,7 +24,7 @@ defmodule ExRLP.EncoderTest do
     string = "\u0001"
     expected_result = "01"
 
-    result = string |> Encoder.encode
+    result = string |> Encoder.encode(encoding: :hex)
 
     assert result == expected_result
   end
@@ -33,7 +33,7 @@ defmodule ExRLP.EncoderTest do
     string = "\u007F"
     expected_result = "7f"
 
-    result = string |> Encoder.encode
+    result = string |> Encoder.encode(encoding: :hex)
 
     assert result == expected_result
   end
@@ -42,7 +42,7 @@ defmodule ExRLP.EncoderTest do
     string = "dog"
     expected_result = "83646f67"
 
-    result = string |> Encoder.encode
+    result = string |> Encoder.encode(encoding: :hex)
 
     assert result == expected_result
   end
@@ -52,7 +52,7 @@ defmodule ExRLP.EncoderTest do
     expected_result = "b74c6f72656d20697073756d20646f6c6f722073697" <>
       "420616d65742c20636f6e7365637465747572206164697069736963696e6720656c69"
 
-    result = string |> Encoder.encode
+    result = string |> Encoder.encode(encoding: :hex)
 
     assert result == expected_result
   end
@@ -62,7 +62,7 @@ defmodule ExRLP.EncoderTest do
     expected_result = "b8384c6f72656d20697073756d20646f6c6f722073697" <>
       "420616d65742c20636f6e7365637465747572206164697069736963696e6720656c6974"
 
-    result = string |> Encoder.encode
+    result = string |> Encoder.encode(encoding: :hex)
 
     assert result == expected_result
   end
@@ -108,7 +108,7 @@ defmodule ExRLP.EncoderTest do
       "e6375732c206d65747573206163206f726e617265206375727375732c20646f6c6f72206a7573746f20" <>
       "756c747269636573206d657475732c20617420756c6c616d636f7270657220766f6c7574706174"
 
-    result = string |> Encoder.encode
+    result = string |> Encoder.encode(encoding: :hex)
 
     assert result == expected_result
   end
@@ -117,7 +117,7 @@ defmodule ExRLP.EncoderTest do
     string = 0
     expected_result = "80"
 
-    result = string |> Encoder.encode
+    result = string |> Encoder.encode(encoding: :hex)
 
     assert result == expected_result
   end
@@ -126,7 +126,7 @@ defmodule ExRLP.EncoderTest do
     string = 1
     expected_result = "01"
 
-    result = string |> Encoder.encode
+    result = string |> Encoder.encode(encoding: :hex)
 
     assert result == expected_result
   end
@@ -135,7 +135,7 @@ defmodule ExRLP.EncoderTest do
     string = 16
     expected_result = "10"
 
-    result = string |> Encoder.encode
+    result = string |> Encoder.encode(encoding: :hex)
 
     assert result == expected_result
   end
@@ -144,7 +144,7 @@ defmodule ExRLP.EncoderTest do
     string = 79
     expected_result = "4f"
 
-    result = string |> Encoder.encode
+    result = string |> Encoder.encode(encoding: :hex)
 
     assert result == expected_result
   end
@@ -153,7 +153,7 @@ defmodule ExRLP.EncoderTest do
     string = 127
     expected_result = "7f"
 
-    result = string |> Encoder.encode
+    result = string |> Encoder.encode(encoding: :hex)
 
     assert result == expected_result
   end
@@ -162,7 +162,7 @@ defmodule ExRLP.EncoderTest do
     string = 128
     expected_result = "8180"
 
-    result = string |> Encoder.encode
+    result = string |> Encoder.encode(encoding: :hex)
 
     assert result == expected_result
   end
@@ -171,7 +171,7 @@ defmodule ExRLP.EncoderTest do
     string = 1000
     expected_result = "8203e8"
 
-    result = string |> Encoder.encode
+    result = string |> Encoder.encode(encoding: :hex)
 
     assert result == expected_result
   end
@@ -180,7 +180,7 @@ defmodule ExRLP.EncoderTest do
     string = 100000
     expected_result = "830186a0"
 
-    result = string |> Encoder.encode
+    result = string |> Encoder.encode(encoding: :hex)
 
     assert result == expected_result
   end
@@ -189,7 +189,7 @@ defmodule ExRLP.EncoderTest do
     string = 83729609699884896815286331701780722
     expected_result = "8f102030405060708090a0b0c0d0e0f2"
 
-    result = string |> Encoder.encode
+    result = string |> Encoder.encode(encoding: :hex)
 
     assert result == expected_result
   end
@@ -198,7 +198,7 @@ defmodule ExRLP.EncoderTest do
     string = 105315505618206987246253880190783558935785933862974822347068935681
     expected_result = "9c0100020003000400050006000700080009000a000b000c000d000e01"
 
-    result = string |> Encoder.encode
+    result = string |> Encoder.encode(encoding: :hex)
 
     assert result == expected_result
   end
@@ -207,7 +207,7 @@ defmodule ExRLP.EncoderTest do
     list = [ "dog", "god", "cat" ]
     expected_result = "cc83646f6783676f6483636174"
 
-    result = list |> Encoder.encode
+    result = list |> Encoder.encode(encoding: :hex)
 
     assert result == expected_result
   end
@@ -216,7 +216,7 @@ defmodule ExRLP.EncoderTest do
     list = [ "zw", [ 4 ], 1 ]
     expected_result = "c6827a77c10401"
 
-    result = list |> Encoder.encode
+    result = list |> Encoder.encode(encoding: :hex)
 
     assert result == expected_result
   end
@@ -227,7 +227,7 @@ defmodule ExRLP.EncoderTest do
     expected_result = "f784617364668471776572847a7863768461736466847" <>
       "1776572847a78637684617364668471776572847a78637684617364668471776572"
 
-    result = list |> Encoder.encode
+    result = list |> Encoder.encode(encoding: :hex)
 
     assert result == expected_result
   end
@@ -242,7 +242,7 @@ defmodule ExRLP.EncoderTest do
     expected_result = "f840cf84617364668471776572847a786376cf84617364668" <>
       "471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376"
 
-    result = list |> Encoder.encode
+    result = list |> Encoder.encode(encoding: :hex)
 
     assert result == expected_result
   end
@@ -302,7 +302,7 @@ defmodule ExRLP.EncoderTest do
       "84617364668471776572847a786376cf84617364668471776572847a" <>
       "786376cf84617364668471776572847a786376"
 
-    result = list |> Encoder.encode
+    result = list |> Encoder.encode(encoding: :hex)
 
     assert result == expected_result
   end
@@ -311,7 +311,7 @@ defmodule ExRLP.EncoderTest do
     list = [ [ [], [] ], [] ]
     expected_result = "c4c2c0c0c0"
 
-    result = list |> Encoder.encode
+    result = list |> Encoder.encode(encoding: :hex)
 
     assert result == expected_result
   end
@@ -320,7 +320,7 @@ defmodule ExRLP.EncoderTest do
     list = [ [], [[]], [ [], [[]] ] ]
     expected_result = "c7c0c1c0c3c0c1c0"
 
-    result = list |> Encoder.encode
+    result = list |> Encoder.encode(encoding: :hex)
 
     assert result == expected_result
   end
@@ -335,7 +335,7 @@ defmodule ExRLP.EncoderTest do
     expected_result = "ecca846b6579318476616c31ca846b65" <>
       "79328476616c32ca846b6579338476616c33ca846b6579348476616c34"
 
-    result = list |> Encoder.encode
+    result = list |> Encoder.encode(encoding: :hex)
 
     assert result == expected_result
   end
@@ -344,7 +344,7 @@ defmodule ExRLP.EncoderTest do
     big_integer = 115792089237316195423570985008687907853269984665640564039457584007913129639936
     expected_result = "a1010000000000000000000000000000000000000000000000000000000000000000"
 
-    result = big_integer |> Encoder.encode
+    result = big_integer |> Encoder.encode(encoding: :hex)
 
     assert result == expected_result
   end
@@ -353,8 +353,9 @@ defmodule ExRLP.EncoderTest do
     map = %{name: "Ayrat", surname: "Badykov", music: "Rock'n'Roll"}
     expected_result = "da8b526f636b276e27526f6c6c85417972617487426164796b6f76"
 
-    result = map |> Encoder.encode
+    result = map |> Encoder.encode(encoding: :hex)
 
     assert result == expected_result
   end
+
 end

--- a/test/ex_rlp_test.exs
+++ b/test/ex_rlp_test.exs
@@ -1,0 +1,5 @@
+defmodule ExRLPTest do
+  use ExUnit.Case, async: true
+  doctest ExRLP
+
+end


### PR DESCRIPTION
This patch makes a few changes, but most importantly, we define a breaking change to make the default encoding of an RLP structure the binary encoding (e.g. <<0x55, 0x66, 0x77>>) instead of hex (e.g. "556677"). This is because the binary encoding is faster and more appropriate when encoding and decoding RLP from the blockchain. We allow a user of ExRLP to return to hex encoding by specifying `encoding: :hex` in the options hash.

Additionally, we merge the test cases from another RLP library and add typespecs for dialyzer.