### PR TITLE
Add Dialyzer for Typespecs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,3 +8,4 @@ jobs:
       - run: mix local.hex --force
       - run: mix deps.get
       - run: mix test
+      - run: mix dialyzer

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,13 @@ jobs:
       - image: elixir:latest
     steps:
       - checkout
+      - restore_cache:
+          key: _build
       - run: mix local.hex --force
       - run: mix deps.get
       - run: mix test
       - run: mix dialyzer
+      - save_cache:
+          key: _build
+          paths:
+            - _build

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule ExRLP.Mixfile do
      elixir: "~> 1.4",
      description: "Ethereum's Recursive Length Prefix (RLP) encoding",
      package: [
-       maintainers: ["Ayrat Badykov"],
+       maintainers: ["Ayrat Badykov", "Geoffrey Hayes"],
        licenses: ["MIT"],
        links: %{"GitHub" => "https://github.com/exthereum/ex_rlp"}
      ],
@@ -23,7 +23,8 @@ defmodule ExRLP.Mixfile do
   defp deps do
     [
       {:credo, "~> 0.8", only: [:dev, :test], runtime: false},
-      {:ex_doc, "~> 0.14", only: :dev, runtime: false}
+      {:ex_doc, "~> 0.14", only: :dev, runtime: false},
+      {:dialyxir, "~> 0.5", only: [:dev], runtime: false},
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
 %{"bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
   "credo": {:hex, :credo, "0.8.1", "137efcc99b4bc507c958ba9b5dff70149e971250813cbe7d4537ec7e36997402", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}], "hexpm"},
+  "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.16.1", "b4b8a23602b4ce0e9a5a960a81260d1f7b29635b9652c67e95b0c2f7ccee5e81", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"}}


### PR DESCRIPTION
This patch adds dialyzer and runs type checks as part of our standard checks. Dialyzer will help us perform static verification of our code.