### PR TITLE
Improve typespec to allow integers to be encoded in RLP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 0.2.1
+* Improve typespecs to allow for integers as a valid value to encode in RLP.
 # 0.2.0
 * Breaking: added option to encode RLP to either hex strings (`"8055FF"`) or binaries (`<<0x80, 0x55, 0xFF>`). The default is now `:binary`.
 * Added typespecs and additional test coverage through doctests.

--- a/lib/ex_rlp.ex
+++ b/lib/ex_rlp.ex
@@ -3,7 +3,7 @@ defmodule ExRLP do
 
   @moduledoc File.read!("#{__DIR__}/../README.md")
 
-  @type t :: nil | [t] | binary()
+  @type t :: nil | binary() | integer() | [t]
 
   @doc """
   Given an RLP structure, returns the encoding as a string.
@@ -49,6 +49,7 @@ defmodule ExRLP do
     iex> ExRLP.encode(for _ <- 1..60, do: [])
     <<248, 60, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192>>
   """
+  @spec encode(t) :: binary()
   @spec encode(t, keyword()) :: binary()
   def encode(item, options \\ []) do
     item |> Encoder.encode(options)
@@ -98,6 +99,8 @@ defmodule ExRLP do
     iex> ExRLP.decode(<<143, 2, 227, 142, 158, 4, 75, 160, 83, 84, 85, 150, 0, 0, 0, 0>>) |> :binary.decode_unsigned
     15_000_000_000_000_000_000_000_000_000_000_000
   """
+  @spec decode(binary()) :: t
+  @spec decode(binary(), atom()) :: t
   @spec decode(binary(), atom(), keyword()) :: t
   def decode(item, type \\ :binary, options \\ []) do
     item |> Decoder.decode(type, options)

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule ExRLP.Mixfile do
 
   def project do
     [app: :ex_rlp,
-     version: "0.2.0",
+     version: "0.2.1",
      elixir: "~> 1.4",
      description: "Ethereum's Recursive Length Prefix (RLP) encoding",
      package: [


### PR DESCRIPTION
The Yellow Paper speaks about only binaries and lists as the types of data which can be RLP encoded, but the actual test cases from Ethereum allow for integers to be encoded directly (which, I guess are basically the same thing as bitstrings). In either case, we allow for this now in our typespecs.